### PR TITLE
fix!: Rename types for clarity

### DIFF
--- a/crates/lexarg-error/examples/hello-error.rs
+++ b/crates/lexarg-error/examples/hello-error.rs
@@ -1,4 +1,4 @@
-use lexarg_error::ErrorContext;
+use lexarg_error::LexError;
 
 struct Args {
     thing: String,
@@ -23,21 +23,21 @@ fn parse_args() -> Result<Args, String> {
         match arg {
             Short("n") | Long("number") => {
                 let value = parser.next_flag_value().ok_or_else(|| {
-                    ErrorContext::msg("missing required value")
+                    LexError::msg("missing required value")
                         .within(arg)
                         .to_string()
                 })?;
                 number = value
                     .to_str()
                     .ok_or_else(|| {
-                        ErrorContext::msg("invalid number")
+                        LexError::msg("invalid number")
                             .unexpected(Value(value))
                             .within(arg)
                             .to_string()
                     })?
                     .parse()
                     .map_err(|e| {
-                        ErrorContext::msg(e)
+                        LexError::msg(e)
                             .unexpected(Value(value))
                             .within(arg)
                             .to_string()
@@ -47,18 +47,17 @@ fn parse_args() -> Result<Args, String> {
                 shout = true;
             }
             Value(val) if thing.is_none() => {
-                thing = Some(val.to_str().ok_or_else(|| {
-                    ErrorContext::msg("invalid string")
-                        .unexpected(arg)
-                        .to_string()
-                })?);
+                thing =
+                    Some(val.to_str().ok_or_else(|| {
+                        LexError::msg("invalid string").unexpected(arg).to_string()
+                    })?);
             }
             Short("h") | Long("help") => {
                 println!("Usage: hello [-n|--number=NUM] [--shout] THING");
                 std::process::exit(0);
             }
             _ => {
-                return Err(ErrorContext::msg("unexpected argument")
+                return Err(LexError::msg("unexpected argument")
                     .unexpected(arg)
                     .to_string());
             }
@@ -68,7 +67,7 @@ fn parse_args() -> Result<Args, String> {
     Ok(Args {
         thing: thing
             .ok_or_else(|| {
-                ErrorContext::msg("missing argument THING")
+                LexError::msg("missing argument THING")
                     .within(Value(bin_name))
                     .to_string()
             })?

--- a/crates/lexarg-error/src/lib.rs
+++ b/crates/lexarg-error/src/lib.rs
@@ -17,13 +17,13 @@
 
 /// Collect context for creating an error
 #[derive(Debug)]
-pub struct ErrorContext<'a> {
+pub struct LexError<'a> {
     msg: String,
     within: Option<lexarg_parser::Arg<'a>>,
     unexpected: Option<lexarg_parser::Arg<'a>>,
 }
 
-impl<'a> ErrorContext<'a> {
+impl<'a> LexError<'a> {
     /// Create a new error object from a printable error message.
     #[cold]
     pub fn msg<M>(message: M) -> Self
@@ -52,7 +52,7 @@ impl<'a> ErrorContext<'a> {
     }
 }
 
-impl<E> From<E> for ErrorContext<'_>
+impl<E> From<E> for LexError<'_>
 where
     E: std::error::Error + Send + Sync + 'static,
 {
@@ -62,7 +62,7 @@ where
     }
 }
 
-impl std::fmt::Display for ErrorContext<'_> {
+impl std::fmt::Display for LexError<'_> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.msg.fmt(formatter)?;
         if let Some(unexpected) = &self.unexpected {

--- a/crates/lexarg/examples/hello.rs
+++ b/crates/lexarg/examples/hello.rs
@@ -1,4 +1,4 @@
-use lexarg::ErrorContext;
+use lexarg::LexError;
 use lexarg::Result;
 
 struct Args {
@@ -40,15 +40,13 @@ fn parse_args() -> Result<Args> {
                 std::process::exit(0);
             }
             Unexpected(_) => {
-                return Err(ErrorContext::msg("unexpected value")
+                return Err(LexError::msg("unexpected value")
                     .unexpected(arg)
                     .within(prev_arg)
                     .into());
             }
             _ => {
-                return Err(ErrorContext::msg("unexpected argument")
-                    .unexpected(arg)
-                    .into());
+                return Err(LexError::msg("unexpected argument").unexpected(arg).into());
             }
         }
         prev_arg = arg;

--- a/crates/libtest-lexarg/examples/libtest-cli.rs
+++ b/crates/libtest-lexarg/examples/libtest-cli.rs
@@ -31,7 +31,7 @@ fn main() -> lexarg::Result<()> {
                 continue;
             }
             Unexpected(_) => {
-                return Err(lexarg::ErrorContext::msg("unexpected value")
+                return Err(lexarg::LexError::msg("unexpected value")
                     .unexpected(arg)
                     .within(prev_arg)
                     .into());
@@ -43,7 +43,7 @@ fn main() -> lexarg::Result<()> {
         let arg = test_opts.parse_next(&mut parser, arg)?;
 
         if let Some(arg) = arg {
-            return Err(lexarg::ErrorContext::msg("unexpected argument")
+            return Err(lexarg::LexError::msg("unexpected argument")
                 .unexpected(arg)
                 .into());
         }

--- a/crates/libtest2-harness/src/case.rs
+++ b/crates/libtest2-harness/src/case.rs
@@ -10,9 +10,9 @@ pub trait Case: Send + Sync + 'static {
     fn kind(&self) -> TestKind;
     fn source(&self) -> Option<&Source>;
     /// This case cannot run in parallel to other cases within this binary
-    fn exclusive(&self, state: &State) -> bool;
+    fn exclusive(&self, state: &TestContext) -> bool;
 
-    fn run(&self, state: &State) -> Result<(), RunError>;
+    fn run(&self, state: &TestContext) -> Result<(), RunError>;
 }
 
 /// Type of the test according to the [rust book](https://doc.rust-lang.org/cargo/guide/tests.html)

--- a/crates/libtest2-harness/src/context.rs
+++ b/crates/libtest2-harness/src/context.rs
@@ -1,12 +1,12 @@
 pub(crate) use crate::*;
 
 #[derive(Debug)]
-pub struct State {
+pub struct TestContext {
     mode: RunMode,
     run_ignored: bool,
 }
 
-impl State {
+impl TestContext {
     pub fn ignore(&self) -> Result<(), RunError> {
         if self.run_ignored {
             Ok(())
@@ -28,7 +28,7 @@ impl State {
     }
 }
 
-impl State {
+impl TestContext {
     pub(crate) fn new() -> Self {
         Self {
             mode: Default::default(),

--- a/crates/libtest2-harness/src/harness.rs
+++ b/crates/libtest2-harness/src/harness.rs
@@ -81,9 +81,7 @@ impl Harness {
 
 const ERROR_EXIT_CODE: i32 = 101;
 
-fn parse<'p>(
-    parser: &mut cli::Parser<'p>,
-) -> Result<libtest_lexarg::TestOpts, cli::ErrorContext<'p>> {
+fn parse<'p>(parser: &mut cli::Parser<'p>) -> Result<libtest_lexarg::TestOpts, cli::LexError<'p>> {
     let mut test_opts = libtest_lexarg::TestOptsBuilder::new();
 
     let bin = parser
@@ -112,7 +110,7 @@ fn parse<'p>(
                 continue;
             }
             cli::Arg::Unexpected(_) => {
-                return Err(cli::ErrorContext::msg("unexpected value")
+                return Err(cli::LexError::msg("unexpected value")
                     .unexpected(arg)
                     .within(prev_arg));
             }
@@ -123,7 +121,7 @@ fn parse<'p>(
         let arg = test_opts.parse_next(parser, arg)?;
 
         if let Some(arg) = arg {
-            return Err(cli::ErrorContext::msg("unexpected argument").unexpected(arg));
+            return Err(cli::LexError::msg("unexpected argument").unexpected(arg));
         }
     }
 

--- a/crates/libtest2-harness/src/lib.rs
+++ b/crates/libtest2-harness/src/lib.rs
@@ -26,16 +26,16 @@
 #![allow(clippy::todo)]
 
 mod case;
+mod context;
 mod harness;
 mod notify;
-mod state;
 
 pub mod cli;
 
 pub use case::*;
+pub use context::*;
 pub use harness::*;
 pub use notify::RunMode;
-pub use state::*;
 
 #[doc = include_str!("../README.md")]
 #[cfg(doctest)]

--- a/crates/libtest2-mimic/examples/mimic-simple.rs
+++ b/crates/libtest2-mimic/examples/mimic-simple.rs
@@ -1,6 +1,6 @@
 use libtest2_mimic::RunError;
 use libtest2_mimic::RunResult;
-use libtest2_mimic::State;
+use libtest2_mimic::TestContext;
 use libtest2_mimic::Trial;
 
 fn main() {
@@ -15,21 +15,21 @@ fn main() {
 
 // Tests
 
-fn check_toph(_state: &State) -> RunResult {
+fn check_toph(_context: &TestContext) -> RunResult {
     Ok(())
 }
-fn check_katara(_state: &State) -> RunResult {
+fn check_katara(_context: &TestContext) -> RunResult {
     Ok(())
 }
-fn check_sokka(_state: &State) -> RunResult {
+fn check_sokka(_context: &TestContext) -> RunResult {
     Err(RunError::fail("Sokka tripped and fell :("))
 }
-fn long_computation(state: &State) -> RunResult {
-    state.ignore_for("slow")?;
+fn long_computation(context: &TestContext) -> RunResult {
+    context.ignore_for("slow")?;
 
     std::thread::sleep(std::time::Duration::from_secs(1));
     Ok(())
 }
-fn compile_fail_dummy(_state: &State) -> RunResult {
+fn compile_fail_dummy(_context: &TestContext) -> RunResult {
     Ok(())
 }

--- a/crates/libtest2-mimic/src/lib.rs
+++ b/crates/libtest2-mimic/src/lib.rs
@@ -27,7 +27,7 @@
 pub use libtest2_harness::Harness;
 pub use libtest2_harness::RunError;
 pub use libtest2_harness::RunResult;
-pub use libtest2_harness::State;
+pub use libtest2_harness::TestContext;
 pub use libtest2_harness::TestKind;
 
 use libtest2_harness::Case;
@@ -36,13 +36,13 @@ use libtest2_harness::Source;
 pub struct Trial {
     name: String,
     #[allow(clippy::type_complexity)]
-    runner: Box<dyn Fn(&State) -> Result<(), RunError> + Send + Sync>,
+    runner: Box<dyn Fn(&TestContext) -> Result<(), RunError> + Send + Sync>,
 }
 
 impl Trial {
     pub fn test(
         name: impl Into<String>,
-        runner: impl Fn(&State) -> Result<(), RunError> + Send + Sync + 'static,
+        runner: impl Fn(&TestContext) -> Result<(), RunError> + Send + Sync + 'static,
     ) -> Self {
         Self {
             name: name.into(),
@@ -61,12 +61,12 @@ impl Case for Trial {
     fn source(&self) -> Option<&Source> {
         None
     }
-    fn exclusive(&self, _: &State) -> bool {
+    fn exclusive(&self, _: &TestContext) -> bool {
         false
     }
 
-    fn run(&self, state: &State) -> Result<(), RunError> {
-        (self.runner)(state)
+    fn run(&self, context: &TestContext) -> Result<(), RunError> {
+        (self.runner)(context)
     }
 }
 

--- a/crates/libtest2/examples/simple.rs
+++ b/crates/libtest2/examples/simple.rs
@@ -1,6 +1,6 @@
 use libtest2::RunError;
 use libtest2::RunResult;
-use libtest2::State;
+use libtest2::TestContext;
 
 libtest2::libtest2_main!(
     check_toph,
@@ -12,21 +12,21 @@ libtest2::libtest2_main!(
 
 // Tests
 
-fn check_toph(_state: &State) -> RunResult {
+fn check_toph(_context: &TestContext) -> RunResult {
     Ok(())
 }
-fn check_katara(_state: &State) -> RunResult {
+fn check_katara(_context: &TestContext) -> RunResult {
     Ok(())
 }
-fn check_sokka(_state: &State) -> RunResult {
+fn check_sokka(_context: &TestContext) -> RunResult {
     Err(RunError::fail("Sokka tripped and fell :("))
 }
-fn long_computation(state: &State) -> RunResult {
-    state.ignore_for("slow")?;
+fn long_computation(context: &TestContext) -> RunResult {
+    context.ignore_for("slow")?;
 
     std::thread::sleep(std::time::Duration::from_secs(1));
     Ok(())
 }
-fn compile_fail_dummy(_state: &State) -> RunResult {
+fn compile_fail_dummy(_context: &TestContext) -> RunResult {
     Ok(())
 }

--- a/crates/libtest2/src/lib.rs
+++ b/crates/libtest2/src/lib.rs
@@ -27,7 +27,7 @@
 pub use libtest2_harness::Harness;
 pub use libtest2_harness::RunError;
 pub use libtest2_harness::RunResult;
-pub use libtest2_harness::State;
+pub use libtest2_harness::TestContext;
 pub use libtest2_harness::TestKind;
 
 use libtest2_harness::Case;
@@ -36,13 +36,13 @@ use libtest2_harness::Source;
 pub struct Trial {
     name: String,
     #[allow(clippy::type_complexity)]
-    runner: Box<dyn Fn(&State) -> Result<(), RunError> + Send + Sync>,
+    runner: Box<dyn Fn(&TestContext) -> Result<(), RunError> + Send + Sync>,
 }
 
 impl Trial {
     pub fn test(
         name: impl Into<String>,
-        runner: impl Fn(&State) -> Result<(), RunError> + Send + Sync + 'static,
+        runner: impl Fn(&TestContext) -> Result<(), RunError> + Send + Sync + 'static,
     ) -> Self {
         Self {
             name: name.into(),
@@ -61,12 +61,12 @@ impl Case for Trial {
     fn source(&self) -> Option<&Source> {
         None
     }
-    fn exclusive(&self, _: &State) -> bool {
+    fn exclusive(&self, _: &TestContext) -> bool {
         false
     }
 
-    fn run(&self, state: &State) -> Result<(), RunError> {
-        (self.runner)(state)
+    fn run(&self, context: &TestContext) -> Result<(), RunError> {
+        (self.runner)(context)
     }
 }
 

--- a/crates/libtest2/tests/testsuite/all_passing.rs
+++ b/crates/libtest2/tests/testsuite/all_passing.rs
@@ -9,15 +9,15 @@ fn test_cmd() -> snapbox::cmd::Command {
             r#"
 libtest2::libtest2_main!(foo, bar, barro);
 
-fn foo(_state: &libtest2::State) -> libtest2::RunResult {
+fn foo(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 
-fn bar(_state: &libtest2::State) -> libtest2::RunResult {
+fn bar(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 
-fn barro(_state: &libtest2::State) -> libtest2::RunResult {
+fn barro(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 "#,

--- a/crates/libtest2/tests/testsuite/argfile.rs
+++ b/crates/libtest2/tests/testsuite/argfile.rs
@@ -9,19 +9,19 @@ fn test_cmd() -> snapbox::cmd::Command {
             r#"
 libtest2::libtest2_main!(one, two, three, one_two);
 
-fn one(_state: &libtest2::State) -> libtest2::RunResult {
+fn one(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 
-fn two(_state: &libtest2::State) -> libtest2::RunResult {
+fn two(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 
-fn three(_state: &libtest2::State) -> libtest2::RunResult {
+fn three(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 
-fn one_two(_state: &libtest2::State) -> libtest2::RunResult {
+fn one_two(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 "#,

--- a/crates/libtest2/tests/testsuite/mixed_bag.rs
+++ b/crates/libtest2/tests/testsuite/mixed_bag.rs
@@ -9,40 +9,40 @@ fn test_cmd() -> snapbox::cmd::Command {
             r#"
 libtest2::libtest2_main!(cat, dog, fox, bunny, frog, owl, fly, bear);
 
-fn cat(_state: &libtest2::State) -> libtest2::RunResult {
+fn cat(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 
-fn dog(_state: &libtest2::State) -> libtest2::RunResult {
+fn dog(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Err(libtest2::RunError::fail("was not a good boy"))
 }
 
-fn fox(_state: &libtest2::State) -> libtest2::RunResult {
+fn fox(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 
-fn bunny(state: &libtest2::State) -> libtest2::RunResult {
-    state.ignore_for("fails")?;
+fn bunny(context: &libtest2::TestContext) -> libtest2::RunResult {
+    context.ignore_for("fails")?;
     Err(libtest2::RunError::fail("jumped too high"))
 }
 
-fn frog(state: &libtest2::State) -> libtest2::RunResult {
-    state.ignore_for("slow")?;
+fn frog(context: &libtest2::TestContext) -> libtest2::RunResult {
+    context.ignore_for("slow")?;
     Ok(())
 }
 
-fn owl(state: &libtest2::State) -> libtest2::RunResult {
-    state.ignore_for("fails")?;
+fn owl(context: &libtest2::TestContext) -> libtest2::RunResult {
+    context.ignore_for("fails")?;
     Err(libtest2::RunError::fail("broke neck"))
 }
 
-fn fly(state: &libtest2::State) -> libtest2::RunResult {
-    state.ignore_for("fails")?;
+fn fly(context: &libtest2::TestContext) -> libtest2::RunResult {
+    context.ignore_for("fails")?;
     Ok(())
 }
 
-fn bear(state: &libtest2::State) -> libtest2::RunResult {
-    state.ignore_for("fails")?;
+fn bear(context: &libtest2::TestContext) -> libtest2::RunResult {
+    context.ignore_for("fails")?;
     Err(libtest2::RunError::fail("no honey"))
 }
 "#,

--- a/crates/libtest2/tests/testsuite/panic.rs
+++ b/crates/libtest2/tests/testsuite/panic.rs
@@ -9,11 +9,11 @@ fn test_cmd() -> snapbox::cmd::Command {
             r#"
 libtest2::libtest2_main!(passes, panics);
 
-fn passes(_state: &libtest2::State) -> libtest2::RunResult {
+fn passes(_context: &libtest2::TestContext) -> libtest2::RunResult {
     Ok(())
 }
 
-fn panics(_state: &libtest2::State) -> libtest2::RunResult {
+fn panics(_context: &libtest2::TestContext) -> libtest2::RunResult {
     panic!("uh oh")
 }
 "#,


### PR DESCRIPTION
My hope is to extend the use of `TestContext` so I feel that name might work better.

I'm unsure if there will be distinct Contexts for different situations, so the name may change further.